### PR TITLE
arm64: dts: rk3328-rock64: add mmc clocks

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
@@ -174,6 +174,10 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
 	status = "okay";
+	supports-emmc;
+	clocks = <&cru HCLK_EMMC>, <&cru SCLK_EMMC>,
+	         <&cru SCLK_EMMC_DRV>, <&cru SCLK_EMMC_SAMPLE>;
+	clock-names = "biu", "ciu", "ciu-drv", "ciu-sample";
 };
 
 &gmac2io {


### PR DESCRIPTION
This is the following commit by ayufan into linux-kernel:

95368b4b832d932f75a1813a056805b84af9cff6
 ayufan: bring back required clocks for emmc to make it working

This fixes the fatal issue on boot:
[    3.003233] mmc_host mmc0: Bus speed (slot 0) = 200000000Hz (slot req 200000000Hz, actual 200000000HZ div = 0)
[    3.004152] dwmmc_rockchip ff520000.dwmmc: Tuning clock (sample_clk) not defined.
[    3.004816] mmc0: tuning execution failed: -5
[    3.005208] mmc0: error -5 whilst initialising MMC card